### PR TITLE
Url Replacement update

### DIFF
--- a/src/main/java/latibot/LatiBot.java
+++ b/src/main/java/latibot/LatiBot.java
@@ -65,7 +65,7 @@ public class LatiBot {
                 .enableCache(CacheFlag.VOICE_STATE)
                 .setChunkingFilter(ChunkingFilter.ALL)
                 .addEventListeners(new CommandListener(), new NicknameListener(), new ReadyListener(),
-                        new ActionListener(), new MessageListener())
+                        new ActionListener(), new MessageListener(), new ReactionListener())
                 .build();
 
         List<SlashCommandData> cmds = Commands.COMMANDS.getCommands().values().stream().flatMap((v) -> {

--- a/src/main/java/latibot/listeners/MessageListener.java
+++ b/src/main/java/latibot/listeners/MessageListener.java
@@ -1,5 +1,6 @@
 package latibot.listeners;
 
+import latibot.LatiBot;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -9,12 +10,14 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
-
-import latibot.LatiBot;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MessageListener extends ListenerAdapter {
 
-    private final String urlRegex = ".*(https?://(www\\.)?\\w+\\.com).*";
+    private static final Pattern urlRegex = Pattern.compile(
+            "(?<fullLink>(https?://(www\\.)?)(?<domain>\\w+\\.com)(.*?(\\?|\\s)))");
+
     private static final HashMap<String, String> domains = new HashMap<>();
 
     public static HashMap<String, String> getDomains() {
@@ -26,34 +29,45 @@ public class MessageListener extends ListenerAdapter {
             String[] urlReplacements = new String((MessageListener.class.getClassLoader().getResourceAsStream("UrlReplacements.txt")).readAllBytes()).split("\n");
             urlReplacements[0] = urlReplacements[0].substring(0, urlReplacements[0].length() - 1);
             for (String s : urlReplacements) {
-                domains.put(s.substring(0, s.indexOf(":")), s.substring(s.indexOf(":") + 1).strip());
+                domains.put(s.substring(0, s.indexOf("|")),
+                        s.substring(s.indexOf("|") + 1).strip());
             }
         } catch (IOException e) {
+            LatiBot.LOG.error("Error reading UrlReplacements.txt");
             throw new RuntimeException(e);
         }
+
     }
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         User author = event.getAuthor();
-        if (author.isBot()) return;
+        if (author.isBot()) return; //must be a user message
         Message message = event.getMessage();
         String content = message.getContentRaw();
-        if(content.startsWith("latibot are you alive")) message.getChannel().sendMessage("you know it baby!!").queue();
-        //checks for any link
+
+        //quick link check
         if (content.contains("https://")) {
-            boolean isReplaced = false;
-            for (String domain : domains.keySet()) {
-                if (content.contains(domain)) {
-                    content = content.replaceAll("/(www\\.)?" + domain, "/" + domains.get(domain)) + "\n";
-                    isReplaced = true;
+            StringBuilder reply = new StringBuilder();
+            Matcher matcher = urlRegex.matcher(content);
+            //actual link check
+            while (matcher.find()) {
+                if (domains.get(matcher.group("domain")) != null) {
+                    reply.append(matcher.group("fullLink")
+                            .replace(matcher.group("domain"), domains.get(matcher.group("domain"))))
+                            .append("\n");
                 }
             }
-            if (isReplaced) {
-                message.reply(content).setSuppressedNotifications(true).queue();
+            if (!reply.toString().isEmpty()) {
+                message.reply(reply).setSuppressedNotifications(true).queue();
                 message.suppressEmbeds(true).queue();
             }
         }
+        /*
+        if (content.toLowerCase().matches("^riggbot (am|is|are|were|do|does|did|have|has|had|can|could|would|should|shall|will|may|might|must).+")) {
+            Random random = new Random();
+            message.getChannel().sendMessage(yesNoAnswers.get(random.nextInt(yesNoAnswers.size()))).queue();
+        }*/
     }
 
     public static boolean saveUrlReplacements() {
@@ -61,9 +75,10 @@ public class MessageListener extends ListenerAdapter {
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
             for (String domain : domains.keySet()) {
-                writer.write(domain + ":" + domains.get(domain));
+                writer.write(domain + "|" + domains.get(domain));
                 writer.newLine();
             }
+            LatiBot.LOG.info("Changes were saved to UrlReplacements.txt");
             return true;
         } catch (IOException e) {
             LatiBot.LOG.error("Error writing to file: " + e.getMessage());

--- a/src/main/java/latibot/listeners/ReactionListener.java
+++ b/src/main/java/latibot/listeners/ReactionListener.java
@@ -1,0 +1,22 @@
+package latibot.listeners;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class ReactionListener extends ListenerAdapter {
+
+    @Override
+    public void onMessageReactionAdd(MessageReactionAddEvent event){
+        Message message = event.retrieveMessage().complete();
+
+        //checks to only trigger on riggbot's messages
+        //TODO: replace riggbot with latibot
+        if(!message.getAuthor().isBot()&&!message.getAuthor().getName().equals("riggbot")) return;
+
+        if(event.getEmoji().toString().equals("🔁")){
+            message.editMessage(message.getContentRaw()).queue();
+            message.removeReaction(event.getEmoji(),event.getUser()).queue();
+        }
+    }
+}

--- a/src/main/resources/UrlReplacements.txt
+++ b/src/main/resources/UrlReplacements.txt
@@ -1,3 +1,3 @@
-tiktok.com:tfxktok.com
-instagram.com:ddinstagram.com
-x.com:stupidpenisx.com
+tiktok.com|tfxktok.com
+x.com|stupidpenisx.com
+instagram.com|ddinstagram.com


### PR DESCRIPTION
Updated link detection with a better regex that also allows a cleaner replacement.
No longer replies with text outside of the links and trims links (this might cause some unforeseen issues, but my limited testing seemed to be fine)